### PR TITLE
Don't crash on empty pages

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -164,7 +164,10 @@ func (page *Page) getMarkdown(provider ImageURLProvider, htmlContent string, foo
 		return nil, fmt.Errorf("error converting HTML to Markdown: %s", err)
 	}
 	if len(strings.TrimSpace(markdown)) == 0 {
-		return nil, fmt.Errorf("empty markdown for %s", page.absoluteURL.String())
+		// The page contains no markdown. Warn the user, but keep going.
+		log.Warn().
+			Str("page", page.absoluteURL.String()).
+			Msg("empty markdown")
 	}
 	if strings.Contains(markdown, _customMoreTag) {
 		// Ref: https://gohugo.io/content-management/summaries/#manual-summary-splitting

--- a/src/wp2hugo/internal/hugogenerator/testdata/testcase.WordPress.2024-07-01.xml
+++ b/src/wp2hugo/internal/hugogenerator/testdata/testcase.WordPress.2024-07-01.xml
@@ -76,6 +76,10 @@
       <wp:meta_key><![CDATA[footnotes]]></wp:meta_key>
       <wp:meta_value><![CDATA[[{"content":"Here we are: the footnote.","id":"082fba72-356e-41c6-acc1-ae0bc20828b2"}]]]></wp:meta_value>
     </wp:postmeta>
+    <wp:postmeta>
+      <wp:meta_key><![CDATA[footnotes]]></wp:meta_key>
+      <wp:meta_value><![CDATA[]]></wp:meta_value><!-- Empty Footnote -->
+    </wp:postmeta>
   </item>
 </channel>
 </rss>

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -509,7 +509,10 @@ func getFootnotes(item *rss.Item) []Footnote {
 		if meta.Children["meta_key"][0].Value != "footnotes" {
 			continue
 		}
-		log.Warn().Msgf("ashishb_meta: %+v", meta)
+		if len(meta.Children["meta_value"][0].Value) == 0 {
+			continue
+		}
+		log.Debug().Msgf("ashishb_meta: %+v", meta)
 		footnoteJSON := meta.Children["meta_value"][0].Value
 		footnoteArr := make([]Footnote, 0)
 		if err := json.Unmarshal([]byte(footnoteJSON), &footnoteArr); err != nil {

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -510,9 +510,11 @@ func getFootnotes(item *rss.Item) []Footnote {
 			continue
 		}
 		if len(meta.Children["meta_value"][0].Value) == 0 {
+			log.Warn().
+				Str("link", item.Link).
+				Msg("ignoring empty footnote")
 			continue
 		}
-		log.Debug().Msgf("ashishb_meta: %+v", meta)
 		footnoteJSON := meta.Children["meta_value"][0].Value
 		footnoteArr := make([]Footnote, 0)
 		if err := json.Unmarshal([]byte(footnoteJSON), &footnoteArr); err != nil {


### PR DESCRIPTION
I've got a page on my site that has only an iframe. Before this commit, wp2hugo would crash when it reached that page but with this change it emits a warning and keeps going, which in my case allows it to finish processing the site.