### PR TITLE
Convert Youtube URLs to Hugo native shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ make build_prod
 1. [x] Set the WordPress homepage correctly
 1. [x] Migrate the RSS feed with existing UUIDs, so that entries appear the same - this is important for anyone with a significant feed following, see more details of a [failed migration](https://theorangeone.net/posts/rss-guids/)
 1. [x] Migrate favicon.ico
-1. [x] Migrate [YouTube embeds](https://support.google.com/youtube/answer/171780)
+1. [x] Migrate [YouTube embeds](https://support.google.com/youtube/answer/171780), including WordPress-style plain-text URLs [pasted](https://wordpress.org/documentation/article/youtube-embed/) into the content
 1. [x] Migrate [Google Map embed](https://developers.google.com/maps/documentation/embed/get-started) via a custom shortcode `googlemaps`
 1. [x] Migrate [GitHub gists](https://gist.github.com/)
 1. [x] Migrate `caption` (WordPress) to `figure` (Hugo)

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -275,6 +275,7 @@ func (page *Page) getMarkdown(provider ImageURLProvider, htmlContent string, foo
 
 	markdown = replaceOrderedListNumbers(markdown)
 	markdown = replaceConsecutiveNewlines(markdown)
+	markdown = replaceYoutubeURL(markdown)
 	markdown = removeTrailingSpaces(markdown)
 
 	return &markdown, nil

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -280,7 +280,7 @@ func (page *Page) getMarkdown(provider ImageURLProvider, htmlContent string, foo
 
 	markdown = replaceOrderedListNumbers(markdown)
 	markdown = replaceConsecutiveNewlines(markdown)
-	markdown = replaceYoutubeURL(markdown)
+	markdown = replacePlaintextYoutubeURL(markdown)
 	markdown = removeTrailingSpaces(markdown)
 
 	return &markdown, nil

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
@@ -1,0 +1,24 @@
+package hugopage
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Example: Plain-text Youtube URLs on their own line in post content are turned by WP into embeds
+var _YoutubeRegEx = regexp.MustCompile(`(?m)(?:^|\s)https?://(?:m.|www.)?(?:youtu.be|youtube.com)/(?:watch|w)\?v=([^&\s]+)`)
+
+func replaceYoutubeURL(htmlData string) string {
+	log.Debug().
+		Msg("Replacing Youtube URLs with embeds")
+
+	htmlData = replaceAllStringSubmatchFunc(_YoutubeRegEx, htmlData, YoutubeReplacementFunction)
+
+	return htmlData
+}
+
+func YoutubeReplacementFunction(groups []string) string {
+	return fmt.Sprintf(`{{< youtube %s >}}`, groups[1])
+}

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
@@ -8,17 +8,14 @@ import (
 )
 
 // Example: Plain-text Youtube URLs on their own line in post content are turned by WP into embeds
-var _YoutubeRegEx = regexp.MustCompile(`(?m)(?:^|\s)https?://(?:m.|www.)?(?:youtu.be|youtube.com)/(?:watch|w)\?v=([^&\s]+)`)
+var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)https?://(?:m.|www.)?(?:youtu.be|youtube.com)/(?:watch|w)\?v=([^&\s]+)`)
 
-func replaceYoutubeURL(htmlData string) string {
+func replacePlaintextYoutubeURL(htmlData string) string {
 	log.Debug().
 		Msg("Replacing Youtube URLs with embeds")
-
-	htmlData = replaceAllStringSubmatchFunc(_YoutubeRegEx, htmlData, YoutubeReplacementFunction)
-
-	return htmlData
+	return replaceAllStringSubmatchFunc(_YoutubeRegEx, htmlData, YoutubeReplacementFunction)
 }
 
 func YoutubeReplacementFunction(groups []string) string {
-	return fmt.Sprintf(`{{< youtube %s >}}`, groups[1])
+	return fmt.Sprintf(`%s{{< youtube %s >}}`, groups[1], groups[2])
 }

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter_test.go
@@ -1,0 +1,33 @@
+package hugopage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceYoutubeURL1(t *testing.T) {
+	const htmlData = "This is a test with a youtube link:\nhttps://www.youtube.com/watch?v=gL0-m1Qlohg"
+	const expected = "This is a test with a youtube link:\n{{< youtube gL0-m1Qlohg >}}"
+	assert.Equal(t, expected, replacePlaintextYoutubeURL(htmlData))
+}
+
+func TestReplaceYoutubeURL2(t *testing.T) {
+	const htmlData = "This is a test with a youtube link: https://www.youtube.com/watch?v=8K7PdBH3W_I"
+	const expected = "This is a test with a youtube link: {{< youtube 8K7PdBH3W_I >}}"
+	assert.Equal(t, expected, replacePlaintextYoutubeURL(htmlData))
+}
+
+func TestReplaceYoutubeURL3(t *testing.T) {
+	const htmlData = "This is a test with a youtube link:\thttps://www.youtube.com/watch?v=gJ7AAJXHeeg whatever"
+	const expected = "This is a test with a youtube link:\t{{< youtube gJ7AAJXHeeg >}} whatever"
+	assert.Equal(t, expected, replacePlaintextYoutubeURL(htmlData))
+}
+
+func TestReplaceNonPlaintextYouTubeURL(t *testing.T) {
+	const htmlData = `This is a test with a youtube link <a href="https://www.youtube.com/watch?v=gJ7AAJXHeeg" and
+		embed <iframe width="560" height="315" src="https://www.youtube.com/embed/Wz6ml5SpkKM?si=rrx_5_80TE3Mz7Co"
+		title="YouTube video player" frameborder="0" allowfullscreen></iframe>`
+	// Assert that the function does not replace the youtube URL in the iframe or the link
+	assert.Equal(t, htmlData, replacePlaintextYoutubeURL(htmlData))
+}


### PR DESCRIPTION
YouTube videos URLs sitting alone on their own line are automatically turned into embeds by WP. We map them here to Hugo native `{{< youtube ID >}}` shortcode for similar feature.