### PR TITLE
Translate WP post_format to Hugo type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ make build_prod
 1. [x] WordPress page author
 1. [x] Ability to filter by author(s), useful for [WordPress multi-site](https://www.smashingmagazine.com/2020/01/complete-guide-wordpress-multisite/) migrations
 1. [x] Featured images - export featured image associations with pages and posts correctly
+1. [x] WordPoress [Post formats](https://developer.wordpress.org/advanced-administration/wordpress/post-formats/)
 
 ### Why existing tools don't work
 

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -365,7 +365,7 @@ func (g Generator) newHugoPage(pageURL *url.URL, page wpparser.CommonFields) (*h
 		g.imageURLProvider,
 		*pageURL, page.Author, page.Title, page.PublishDate,
 		page.PublishStatus == wpparser.PublishStatusDraft || page.PublishStatus == wpparser.PublishStatusPending,
-		page.Categories, page.Tags, page.Footnotes, page.Content, page.GUID, page.FeaturedImageID)
+		page.Categories, page.Tags, page.Footnotes, page.Content, page.GUID, page.FeaturedImageID, page.PostFormat)
 }
 
 func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page, pageURL *url.URL) error {

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -64,8 +64,8 @@ var _hugoParallaxBlurLinks = regexp.MustCompile(`{{< parallaxblur.*?src="(.+?)".
 
 func NewPage(provider ImageURLProvider, pageURL url.URL, author string, title string, publishDate *time.Time,
 	isDraft bool, categories []string, tags []string, footnotes []wpparser.Footnote,
-	htmlContent string, guid *rss.GUID, featuredImageID *string) (*Page, error) {
-	metadata, err := getMetadata(provider, pageURL, author, title, publishDate, isDraft, categories, tags, guid, featuredImageID)
+	htmlContent string, guid *rss.GUID, featuredImageID *string, postFormat string) (*Page, error) {
+	metadata, err := getMetadata(provider, pageURL, author, title, publishDate, isDraft, categories, tags, guid, featuredImageID, postFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func getMarkdownLinks(regex *regexp.Regexp, markdown string) []string {
 }
 
 func getMetadata(provider ImageURLProvider, pageURL url.URL, author string, title string, publishDate *time.Time,
-	isDraft bool, categories []string, tags []string, guid *rss.GUID, featuredImageID *string) (map[string]any, error) {
+	isDraft bool, categories []string, tags []string, guid *rss.GUID, featuredImageID *string, postFormat string) (map[string]any, error) {
 	metadata := make(map[string]any)
 	metadata["url"] = pageURL.Path // Relative URL
 	metadata["author"] = author
@@ -162,6 +162,9 @@ func getMetadata(provider ImageURLProvider, pageURL url.URL, author string, titl
 			coverInfo["alt"] = imageInfo.Title
 			metadata["cover"] = coverInfo
 		}
+	}
+	if postFormat != "" {
+		metadata["type"] = postFormat
 	}
 	return metadata, nil
 }

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -64,8 +64,9 @@ var _hugoParallaxBlurLinks = regexp.MustCompile(`{{< parallaxblur.*?src="(.+?)".
 
 func NewPage(provider ImageURLProvider, pageURL url.URL, author string, title string, publishDate *time.Time,
 	isDraft bool, categories []string, tags []string, footnotes []wpparser.Footnote,
-	htmlContent string, guid *rss.GUID, featuredImageID *string, postFormat string) (*Page, error) {
-	metadata, err := getMetadata(provider, pageURL, author, title, publishDate, isDraft, categories, tags, guid, featuredImageID, postFormat)
+	htmlContent string, guid *rss.GUID, featuredImageID *string, postFormat *string) (*Page, error) {
+	metadata, err := getMetadata(provider, pageURL, author, title, publishDate, isDraft, categories, tags, guid,
+		featuredImageID, postFormat)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,8 @@ func getMarkdownLinks(regex *regexp.Regexp, markdown string) []string {
 }
 
 func getMetadata(provider ImageURLProvider, pageURL url.URL, author string, title string, publishDate *time.Time,
-	isDraft bool, categories []string, tags []string, guid *rss.GUID, featuredImageID *string, postFormat string) (map[string]any, error) {
+	isDraft bool, categories []string, tags []string, guid *rss.GUID, featuredImageID *string,
+	postFormat *string) (map[string]any, error) {
 	metadata := make(map[string]any)
 	metadata["url"] = pageURL.Path // Relative URL
 	metadata["author"] = author
@@ -163,8 +165,8 @@ func getMetadata(provider ImageURLProvider, pageURL url.URL, author string, titl
 			metadata["cover"] = coverInfo
 		}
 	}
-	if postFormat != "" {
-		metadata["type"] = postFormat
+	if postFormat != nil {
+		metadata["type"] = *postFormat
 	}
 	return metadata, nil
 }

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page_test.go
@@ -62,7 +62,7 @@ func TestManualLineBreaks(t *testing.T) {
 func testMarkdownExtractor(t *testing.T, htmlInput string, markdownOutput string) {
 	url1, err := url.Parse("https://example.com")
 	assert.Nil(t, err)
-	page, err := NewPage(nil, *url1, "author", "Title", nil, false, nil, nil, nil, htmlInput, nil, nil)
+	page, err := NewPage(nil, *url1, "author", "Title", nil, false, nil, nil, nil, htmlInput, nil, nil, nil)
 	assert.Nil(t, err)
 	md, err := page.getMarkdown(nil, htmlInput, nil)
 	assert.Nil(t, err)

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -93,7 +93,7 @@ type CommonFields struct {
 	LastModifiedDate *time.Time
 	PublishStatus    PublishStatus // "publish", "draft", "pending" etc. may be make this a custom type
 	GUID             *rss.GUID
-	PostFormat       string
+	PostFormat       *string
 
 	Description string // how to use this?
 	Content     string
@@ -309,7 +309,7 @@ func getCommonFields(item *rss.Item) (*CommonFields, error) {
 	}
 	pageCategories := make([]string, 0, len(item.Categories))
 	pageTags := make([]string, 0, len(item.Categories))
-	var postFormat string
+	var postFormat *string
 
 	for _, category := range item.Categories {
 		if isCategory(category) {
@@ -317,7 +317,8 @@ func getCommonFields(item *rss.Item) (*CommonFields, error) {
 		} else if isTag(category) {
 			pageTags = append(pageTags, NormalizeCategoryName(category.Value))
 		} else if isPostFormat(category) {
-			postFormat = NormalizeCategoryName(category.Value)
+			tmp := NormalizeCategoryName(category.Value)
+			postFormat = &tmp
 		} else {
 			log.Warn().
 				Str("link", item.Link).

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mmcdole/gofeed/extensions"
-	"github.com/mmcdole/gofeed/rss"
-	"github.com/rs/zerolog/log"
-	"golang.org/x/text/runes"
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 	"io"
 	"regexp"
 	"strings"
 	"time"
 	"unicode"
+
+	ext "github.com/mmcdole/gofeed/extensions"
+	"github.com/mmcdole/gofeed/rss"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 var (
@@ -92,6 +93,7 @@ type CommonFields struct {
 	LastModifiedDate *time.Time
 	PublishStatus    PublishStatus // "publish", "draft", "pending" etc. may be make this a custom type
 	GUID             *rss.GUID
+	PostFormat       string
 
 	Description string // how to use this?
 	Content     string
@@ -307,12 +309,15 @@ func getCommonFields(item *rss.Item) (*CommonFields, error) {
 	}
 	pageCategories := make([]string, 0, len(item.Categories))
 	pageTags := make([]string, 0, len(item.Categories))
+	var postFormat string
 
 	for _, category := range item.Categories {
 		if isCategory(category) {
 			pageCategories = append(pageTags, NormalizeCategoryName(category.Value))
 		} else if isTag(category) {
 			pageTags = append(pageTags, NormalizeCategoryName(category.Value))
+		} else if isPostFormat(category) {
+			postFormat = NormalizeCategoryName(category.Value)
 		} else {
 			log.Warn().
 				Str("link", item.Link).
@@ -358,6 +363,7 @@ func getCommonFields(item *rss.Item) (*CommonFields, error) {
 		GUID:             item.GUID,
 		LastModifiedDate: lastModifiedDate,
 		PublishStatus:    PublishStatus(publishStatus),
+		PostFormat:       postFormat,
 		Excerpt:          item.Extensions["excerpt"]["encoded"][0].Value,
 
 		Description:     item.Description,
@@ -469,6 +475,10 @@ func getNavigationLink(match string) (*NavigationLink, error) {
 
 func isCategory(category *rss.Category) bool {
 	return category.Domain == "category"
+}
+
+func isPostFormat(category *rss.Category) bool {
+	return category.Domain == "post_format"
 }
 
 func isTag(tag *rss.Category) bool {


### PR DESCRIPTION
Allow to apply conditional templates based on types, beyond the mere post/page dichotomy. 

WP `post_format` is written in pages frontmatter under the `type` field. Hugo will then apply the page template matching the `type` value, if any.

Notes:

- WP post_format: https://developer.wordpress.org/advanced-administration/wordpress/post-formats/
- Hugo type: https://gohugo.io/content-management/types/
- WP allows only a predefined set of normalized types. Hugo supports anything templated.