### PR TITLE
Support WP audio shortcode

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/custom_shortcodes.go
+++ b/src/wp2hugo/internal/hugogenerator/custom_shortcodes.go
@@ -107,10 +107,18 @@ const _ParallaxBlurShortCode = `{{ $imgURL := .Get "src" }}
 </div>
 `
 
+const _audioShortCode = `
+<audio controls preload="metadata">
+  <source src="{{ .Get "src" }}" type="audio/{{ replace (path.Ext (.Get "src")) "." ""}}">
+  Your browser does not support the audio element.
+</audio>
+`
+
 func WriteCustomShortCodes(siteDir string) error {
 	return errors.Join(writeGoogleMapsShortCode(siteDir),
 		writeSelectedPostsShortCode(siteDir),
-		writeParallaxBlurShortCode(siteDir))
+		writeParallaxBlurShortCode(siteDir),
+		writeAudioShortCode(siteDir))
 }
 
 func writeGoogleMapsShortCode(siteDir string) error {
@@ -123,6 +131,10 @@ func writeSelectedPostsShortCode(siteDir string) error {
 
 func writeParallaxBlurShortCode(siteDir string) error {
 	return writeShortCode(siteDir, "parallaxblur", _ParallaxBlurShortCode)
+}
+
+func writeAudioShortCode(siteDir string) error {
+	return writeShortCode(siteDir, "audio", _audioShortCode)
 }
 
 func writeShortCode(siteDir string, shortCodeName string, fileContent string) error {

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -213,6 +213,7 @@ func (page *Page) getMarkdown(provider ImageURLProvider, htmlContent string, foo
 	converter := getMarkdownConverter()
 	htmlContent = improvePreTagsWithCode(htmlContent)
 	htmlContent = replaceCaptionWithFigure(htmlContent)
+	htmlContent = replaceAudioShortCode(htmlContent)
 	htmlContent = replaceAWBWithParallaxBlur(provider, htmlContent)
 	htmlContent = strings.Replace(htmlContent, _WordPressMoreTag, _customMoreTag, 1)
 

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter.go
@@ -1,0 +1,75 @@
+package hugopage
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Examples:
+//  1. [audio mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"][/audio]
+//  2. [audio src="audio-source.mp3"]
+//  3. [audio mp3="source.mp3" ogg="source.ogg" wav="source.wav" m4a="source.m4a"]
+//  4. [audio] is allowed by WP but is not covered here since WP extracts the first link to mp3/ogg/wav/m4a found in post.
+//     this case is inconvenient for us and pretty niche.
+//
+// Reference : https://wordpress.org/documentation/article/audio-shortcode/
+var _AudioRegEx = regexp.MustCompile(`\[audio ([^\]]+)\](.*)(?:\[\/audio\])?`)
+
+var _srcRegEx = regexp.MustCompile(`src="([^"]+)"`)
+var _mp3RegEx = regexp.MustCompile(`mp3="([^"]+)"`)
+var _m4aRegEx = regexp.MustCompile(`m4a="([^"]+)"`)
+var _oggRegEx = regexp.MustCompile(`ogg="([^"]+)"`)
+var _wavRegEx = regexp.MustCompile(`wav="([^"]+)"`)
+
+func replaceAudioShortCode(htmlData string) string {
+	log.Debug().
+		Msg("Replacing Audio shortcodes")
+	return replaceAllStringSubmatchFunc(_AudioRegEx, htmlData, AudioReplacementFunction)
+}
+
+func printAudioShortCode(src string) string {
+	// These characters create problems in Hugo's markdown
+	src = strings.ReplaceAll(src, " ", "%20")
+	src = strings.ReplaceAll(src, "_", "%5F")
+	return fmt.Sprintf(`{{< audio src="%s" >}}`, src)
+}
+
+func AudioReplacementFunction(groups []string) string {
+	args := groups[1]
+
+	// We look for, in this order : m4a, mp3, src, ogg, wav ; then take the first.
+	// Reason is m4a and mp3 are the most widely supported.
+	// We could support all alternatives at once, using <source>, and let the browser decide
+	// but is it worth the trouble ?
+	// Reference : https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs
+
+	m4a := _m4aRegEx.FindStringSubmatch(args)
+	if m4a != nil {
+		return printAudioShortCode(m4a[1])
+	}
+
+	mp3 := _mp3RegEx.FindStringSubmatch(args)
+	if mp3 != nil {
+		return printAudioShortCode(mp3[1])
+	}
+
+	src := _srcRegEx.FindStringSubmatch(args)
+	if src != nil {
+		return printAudioShortCode(src[1])
+	}
+
+	ogg := _oggRegEx.FindStringSubmatch(args)
+	if ogg != nil {
+		return printAudioShortCode(ogg[1])
+	}
+
+	wav := _wavRegEx.FindStringSubmatch(args)
+	if wav != nil {
+		return printAudioShortCode(wav[1])
+	}
+
+	return ""
+}

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
@@ -1,0 +1,25 @@
+package hugopage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceAudio1(t *testing.T) {
+	const htmlData = `[audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"][/audio]`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
+	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
+}
+
+func TestReplaceAudio2(t *testing.T) {
+	const htmlData = `[audio mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
+	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
+}
+
+func TestReplaceAudio3(t *testing.T) {
+	const htmlData = `[audio m4a="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.m4a" mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.m4a" >}}`
+	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
+}


### PR DESCRIPTION
1. add our own basic custom Hugo shortcode, using HTML5 audio: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
2. convert WP audio shortcode: https://wordpress.org/documentation/article/audio-shortcode/
3. add unit tests

Note: audio files added to WP media library and used in audio shortcode are not downloaded into the Hugo assets. I didn't investigate how to make that happen, it seems media are assumed to be image only but I didn't find where everything else gets filtered.