### PR TITLE
Improve audio support

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -397,7 +397,7 @@ func (g Generator) newHugoPage(pageURL *url.URL, page wpparser.CommonFields) (*h
 }
 
 func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page, pageURL *url.URL) error {
-	links := p.WPImageLinks()
+	links := p.WPMediaLinks()
 	log.Debug().
 		Str("page", pageURL.String()).
 		Int("links", len(links)).

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -57,10 +57,14 @@ var (
 
 // Extracts "src" from Hugo figure shortcode
 // {{< figure align=aligncenter width=905 src="/wp-content/uploads/2023/01/Stollemeyer-castle-1024x768.jpg" alt="" >}}
-var _hugoFigureLinks = regexp.MustCompile(`{{< figure.*?src="(.+?)".*? >}}`)
+var _hugoFigureLinks = regexp.MustCompile(`{{< figure.*?src="([^\"]+?)".*? >}}`)
+
+// Extracts "src" from Hugo audio shortcode
+// {{< audio src="/wp-content/uploads/2023/01/session.mp3" alt="" >}}
+var _hugoAudioLinks = regexp.MustCompile(`{{< audio.*?src="([^\"]+?)".*? >}}`)
 
 // {{< parallaxblur src="/wp-content/uploads/2018/12/bora%5Fbora%5F5%5Fresized.jpg" >}}
-var _hugoParallaxBlurLinks = regexp.MustCompile(`{{< parallaxblur.*?src="(.+?)".*? >}}`)
+var _hugoParallaxBlurLinks = regexp.MustCompile(`{{< parallaxblur.*?src="([^\"]+?)".*? >}}`)
 
 func NewPage(provider ImageURLProvider, pageURL url.URL, author string, title string, publishDate *time.Time,
 	isDraft bool, categories []string, tags []string, footnotes []wpparser.Footnote,
@@ -98,12 +102,13 @@ func (page Page) Write(w io.Writer) error {
 	return nil
 }
 
-func (page *Page) WPImageLinks() []string {
+func (page *Page) WPMediaLinks() []string {
 	arr1 := getMarkdownLinks(_markdownImageLinks, page.markdown)
 	arr2 := getMarkdownLinks(_hugoFigureLinks, page.markdown)
 	arr3 := getMarkdownLinks(_hugoParallaxBlurLinks, page.markdown)
+	arr4 := getMarkdownLinks(_hugoAudioLinks, page.markdown)
 	coverImageURL := page.getCoverImageURL()
-	result := append(append(arr1, arr2...), arr3...)
+	result := append(append(append(arr1, arr2...), arr3...), arr4...)
 	if coverImageURL != nil {
 		result = append(result, *coverImageURL)
 	}

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter.go
@@ -14,9 +14,13 @@ import (
 //  3. [audio mp3="source.mp3" ogg="source.ogg" wav="source.wav" m4a="source.m4a"]
 //  4. [audio] is allowed by WP but is not covered here since WP extracts the first link to mp3/ogg/wav/m4a found in post.
 //     this case is inconvenient for us and pretty niche.
+//  5. Gutenberg editor directly writes audio HTML, like :
+//     <figure class="wp-block-audio"><audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" controls="controls"></audio></figure>
+//     Gutenberg can optionnaly nest <figcaption> into <figure>, below <audio>. We disregard it here.
 //
 // Reference : https://wordpress.org/documentation/article/audio-shortcode/
-var _AudioRegEx = regexp.MustCompile(`\[audio ([^\]]+)\](.*)(?:\[\/audio\])?`)
+var _AudioShortCodeRegEx = regexp.MustCompile(`\[audio ([^\]]+)\](?:.*)(?:\[\/audio\])?`)
+var _AudioHTMLRegEx = regexp.MustCompile(`<figure (?:.*?)class="(?:.*?)wp-block-audio(?:.*?)">\s*<audio ([^<>]*?)\/?>(?:<\/audio>)?(?:[\s\S]*?)</figure>`)
 
 var _srcRegEx = regexp.MustCompile(`src="([^"]+)"`)
 var _mp3RegEx = regexp.MustCompile(`mp3="([^"]+)"`)
@@ -27,7 +31,9 @@ var _wavRegEx = regexp.MustCompile(`wav="([^"]+)"`)
 func replaceAudioShortCode(htmlData string) string {
 	log.Debug().
 		Msg("Replacing Audio shortcodes")
-	return replaceAllStringSubmatchFunc(_AudioRegEx, htmlData, AudioReplacementFunction)
+	htmlData = replaceAllStringSubmatchFunc(_AudioShortCodeRegEx, htmlData, AudioReplacementFunction)
+	htmlData = replaceAllStringSubmatchFunc(_AudioHTMLRegEx, htmlData, AudioReplacementFunction)
+	return htmlData
 }
 
 func printAudioShortCode(src string) string {

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
@@ -8,31 +8,31 @@ import (
 
 func TestReplaceAudio1(t *testing.T) {
 	const htmlData = `[audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"][/audio]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio2(t *testing.T) {
 	const htmlData = `[audio mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio3(t *testing.T) {
 	const htmlData = `[audio m4a="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.m4a" mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.m4a" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.m4a" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio4(t *testing.T) {
 	const htmlData = `<figure class="wp-block-audio aligncenter"><audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" controls="controls"></audio>
 	</figure>`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio5(t *testing.T) {
 	const htmlData = `<figure class="wp-block-audio"><audio controls="" src="file_example_mp3_700kb.mp3"></audio><figcaption class="wp-element-caption">An example of the audio player</figcaption></figure>`
-	const expected = `{{< audio src="file_example_mp3_700kb.mp3" >}}`
+	const expected = `{{< audio src="file%5Fexample%5Fmp3%5F700kb.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_audio_converter_test.go
@@ -8,18 +8,31 @@ import (
 
 func TestReplaceAudio1(t *testing.T) {
 	const htmlData = `[audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"][/audio]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio2(t *testing.T) {
 	const htmlData = `[audio mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.mp3" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }
 
 func TestReplaceAudio3(t *testing.T) {
 	const htmlData = `[audio m4a="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.m4a" mp3="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3"]`
-	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session%5F2020-07-02.m4a" >}}`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.m4a" >}}`
+	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
+}
+
+func TestReplaceAudio4(t *testing.T) {
+	const htmlData = `<figure class="wp-block-audio aligncenter"><audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" controls="controls"></audio>
+	</figure>`
+	const expected = `{{< audio src="/wp-content/uploads/sites/3/2020/07/session_2020-07-02.mp3" >}}`
+	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
+}
+
+func TestReplaceAudio5(t *testing.T) {
+	const htmlData = `<figure class="wp-block-audio"><audio controls="" src="file_example_mp3_700kb.mp3"></audio><figcaption class="wp-element-caption">An example of the audio player</figcaption></figure>`
+	const expected = `{{< audio src="file_example_mp3_700kb.mp3" >}}`
 	assert.Equal(t, expected, replaceAudioShortCode(htmlData))
 }


### PR DESCRIPTION
- support audio attachments added from Gutenberg audio block (directly using HTML)
- download target audio files locally into `/static` (partially address #50)
- optimize media URL finding regex

Reference: https://wordpress.com/support/wordpress-editor/blocks/audio-block/