### PR TITLE
fix filenames for media with query values

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -419,6 +419,10 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 		for _, prefix := range prefixes {
 			link = strings.TrimPrefix(link, prefix)
 		}
+		url, _ := url.Parse(link)
+
+		link = strings.TrimSuffix(link, fmt.Sprintf("?%s", url.RawQuery))
+
 		if !strings.HasPrefix(link, "/") {
 			log.Warn().
 				Str("link", link).


### PR DESCRIPTION
wordpress.com's CMS automatically adds query values for images in a few cases.

when wp2hugo downloads media of  URLs with query values, e.g. `foo.png?q=1` migrated pages fail to load this media.

the media file is stored with the filename that includes the query values (foo.png?q=1) but the markdown only refers to the path (foo.png).

this patch removes the query values from the filenames on disk.