### PR TITLE
Handle // scheme prefix

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -425,8 +425,8 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 
 	for _, link := range links {
 		if strings.HasPrefix(link, "//") {
- 			link = strings.Replace(link, "//", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
-    		}
+			link = strings.Replace(link, "//", fmt.Sprintf("%s://", pageURL.Scheme), 1)
+		}
 		for _, prefix := range prefixes {
 			link = strings.TrimPrefix(link, prefix)
 		}

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -424,8 +424,8 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 	prefixes = append(prefixes, fmt.Sprintf("http://www.%s", hostname))
 
 	for _, link := range links {
-		if strings.HasPrefix(link, "///") {
-      link = strings.Replace(link, "///", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
+		if strings.HasPrefix(link, "//") {
+      link = strings.Replace(link, "//", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
     }
 		for _, prefix := range prefixes {
 			link = strings.TrimPrefix(link, prefix)

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -424,6 +424,9 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 	prefixes = append(prefixes, fmt.Sprintf("http://www.%s", hostname))
 
 	for _, link := range links {
+		if strings.HasPrefix(link, "///") {
+      link = strings.Replace(link, "///", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
+    }
 		for _, prefix := range prefixes {
 			link = strings.TrimPrefix(link, prefix)
 		}

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -425,8 +425,8 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 
 	for _, link := range links {
 		if strings.HasPrefix(link, "//") {
-      link = strings.Replace(link, "//", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
-    }
+ 			link = strings.Replace(link, "//", fmt.Sprintf("%s://", pageURL.Scheme) , 1)
+    		}
 		for _, prefix := range prefixes {
 			link = strings.TrimPrefix(link, prefix)
 		}


### PR DESCRIPTION
Fixes #74

During media download, if the scheme is expressed as `//` replaces with the current URL's scheme before proceeding through the process.