### PR TITLE
fix: bug in tags being treated as categories

### DIFF
--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -337,7 +337,7 @@ func getCommonFields(item *rss.Item) (*CommonFields, error) {
 
 	for _, category := range item.Categories {
 		if isCategory(category) {
-			pageCategories = append(pageTags, NormalizeCategoryName(category.Value))
+			pageCategories = append(pageCategories, NormalizeCategoryName(category.Value))
 		} else if isTag(category) {
 			pageTags = append(pageTags, NormalizeCategoryName(category.Value))
 		} else if isPostFormat(category) {


### PR DESCRIPTION
Tags were being appended into categories.
This commit fixes that.

Ref: https://github.com/ashishb/wp2hugo/issues/76