### PR TITLE
Support YouTube Lyte embeds

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Example: Plain-text Youtube URLs on their own line in post content are turned by WP into embeds
-var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)https?://(?:m\.|www\.)?(?:youtu\.be|youtube\.com)/(?:watch|w)\?v=([^&\s]+)`)
+var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)http[sav]?://(?:m\.|www\.)?(?:youtu\.be|youtube\.com)/(?:watch|w)\?v=([^&\s]+)`)
 
 func replacePlaintextYoutubeURL(htmlData string) string {
 	log.Debug().

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
@@ -8,6 +8,8 @@ import (
 )
 
 // Example: Plain-text Youtube URLs on their own line in post content are turned by WP into embeds
+// The YouTube Lyte plug-in additionally uses "httpa://" for audio and "httpv://" for video embeds:
+// https://wordpress.com/plugins/wp-youtube-lyte 
 var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)http[sav]?://(?:m\.|www\.)?(?:youtu\.be|youtube\.com)/(?:watch|w)\?v=([^&\s]+)`)
 
 func replacePlaintextYoutubeURL(htmlData string) string {


### PR DESCRIPTION
For quite a few years, I have been using [YouTube Lyte](https://wordpress.com/plugins/wp-youtube-lyte) for my YouTube embeds in WordPress, which uses plain text embeds, but adds two new "virtual URL schemes", namely `httpa`  for audio-only embeds and `httpv` for video embeds. This non-destructive change supports YouTube Lyte.