### PR TITLE
Image attachments: use full-resolution file if available

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -502,9 +502,9 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 			// If full-res image found, update target file path too
 			outputFilePath = _resizedMedia.ReplaceAllString(outputFilePath, "$1.$2")
 			log.Info().
-			Str("fullResLink", fullResLink).
-			Str("link", link).
-			Msg("resized thumbnail was replaced by full-resolution image")
+				Str("fullResLink", fullResLink).
+				Str("link", link).
+				Msg("resized thumbnail was replaced by full-resolution image")
 		}
 
 		if err != nil {

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -493,6 +493,9 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 			// If full-res image not found, try again with resized one.
 
 			media, err = g.mediaProvider.GetReader(link)
+		} else {
+			// If full-res image found, update target file path too
+			outputFilePath = _resizedMedia.ReplaceAllString(outputFilePath, "$1.$2")
 		}
 
 		if err != nil {

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -491,11 +491,20 @@ func (g Generator) downloadPageMedia(outputMediaDirPath string, p *hugopage.Page
 
 		if err != nil {
 			// If full-res image not found, try again with resized one.
-
-			media, err = g.mediaProvider.GetReader(link)
+			if strings.Compare(fullResLink, link) != 0 {
+				log.Info().
+					Str("fullResLink", fullResLink).
+					Str("link", link).
+					Msg("full-resolution image file not found, falling back to resized thumbnail")
+				media, err = g.mediaProvider.GetReader(link)
+			} // else fullResLink == link, so no need to retry
 		} else {
 			// If full-res image found, update target file path too
 			outputFilePath = _resizedMedia.ReplaceAllString(outputFilePath, "$1.$2")
+			log.Info().
+			Str("fullResLink", fullResLink).
+			Str("link", link).
+			Msg("resized thumbnail was replaced by full-resolution image")
 		}
 
 		if err != nil {


### PR DESCRIPTION
Images embedded in posts/pages may sometimes use downscaled image thumbnails or thumbnails sizes that don't exist anymore, patterned like `some-file-1920x1080.jpg`. We try to find the full-resolution image if any, like `some-file.jpg`, then fall-back to whatever URL was given in content if this failed.

This assumes Hugo image partials will handle resizing to theme width and responsive image sizes internally (see https://discourse.gohugo.io/t/hugo-image-processing-and-responsive-images/43110/4).