### PR TITLE
feat: add `suggest-image-alt`

### DIFF
--- a/src/wp2hugo/cmd/hugomanager/cmd/suggest_description.go
+++ b/src/wp2hugo/cmd/hugomanager/cmd/suggest_description.go
@@ -26,7 +26,7 @@ var _suggestDescriptionCmd = &cobra.Command{
 	Short: "Suggests description for all the posts that are missing a description in the front matter",
 	Long:  "Suggests description for all the posts that are missing a description in the front matter",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Info().Msg("URL Suggest command called")
+		log.Info().Msg("suggest-description command called")
 		logger.ConfigureLogging(_colorLogOutput)
 
 		numHasDescription := 0

--- a/src/wp2hugo/cmd/hugomanager/cmd/suggest_image_alt.go
+++ b/src/wp2hugo/cmd/hugomanager/cmd/suggest_image_alt.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ashishb/wp2hugo/src/wp2hugo/internal/hugomanager/imagealtsuggest"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"strings"
+
+	"github.com/ashishb/wp2hugo/src/wp2hugo/internal/logger"
+)
+
+func init() {
+	_suggestImageAltCmd.Flags().StringVarP(&_hugoDir, "hugo-dir", "", "", "Hugo base directory or any directory containing Hugo markdown files")
+	_suggestImageAltCmd.Flags().BoolVarP(&_updateInline, "in-place", "", false, "Add image alt in markdown files")
+	_suggestImageAltCmd.PersistentFlags().BoolVarP(&_colorLogOutput, "color-log-output", "", true,
+		"enable colored log output, set false to structured JSON log")
+	_suggestImageAltCmd.Flags().IntVarP(&_limit, "limit", "n", 10, "Limit the number of images to update")
+	rootCmd.AddCommand(_suggestImageAltCmd)
+}
+
+var _suggestImageAltCmd = &cobra.Command{
+	Use:   "suggest-image-alt",
+	Short: "Suggests image alt text for all the images if missing",
+	Long:  "Suggests image alt text for all the images that are missing alt text (useful for accessibility and SEO)",
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Info().Msg("suggest-image-alt command called")
+		logger.ConfigureLogging(_colorLogOutput)
+		numImageWithAlt := 0
+		numImageMissingAlt := 0
+		numImageUpdated := 0
+		ctx := cmd.Context()
+		action := func(path string, updateInline bool) error {
+			if !strings.HasSuffix(strings.ToLower(path), ".md") {
+				log.Debug().
+					Str("path", path).
+					Msg("Skipping non-markdown file")
+				return nil
+			}
+			if numImageUpdated >= _limit {
+				log.Info().
+					Int("numImageUpdated", numImageUpdated).
+					Msg("Limit reached, stopping further updates")
+				return nil
+			}
+
+			result, err := imagealtsuggest.ProcessFile(ctx, path, updateInline)
+			if err != nil {
+				return fmt.Errorf("failed to process file %s: %w", path, err)
+			}
+
+			numImageWithAlt += result.NumImageWithAlt()
+			numImageMissingAlt += result.NumImageMissingAlt()
+			numImageUpdated += result.NumImageUpdated()
+			if result.NumImageUpdated() > 0 {
+				log.Debug().
+					Str("path", path).
+					Int("numImageUpdated", result.NumImageUpdated()).
+					Msg("Updated description in front matter")
+			}
+
+			return err
+		}
+		scanDir(_hugoDir, _updateInline, action)
+		log.Info().
+			Int("numImageWithAlt", numImageWithAlt).
+			Int("numImageMissingAlt", numImageMissingAlt).
+			Int("numImageUpdated", numImageUpdated).
+			Msg("Image alt text suggestion completed")
+	},
+}

--- a/src/wp2hugo/internal/hugomanager/imagealtsuggest/image_alt_suggest.go
+++ b/src/wp2hugo/internal/hugomanager/imagealtsuggest/image_alt_suggest.go
@@ -1,0 +1,86 @@
+package imagealtsuggest
+
+import (
+	"context"
+	"fmt"
+	"github.com/adrg/frontmatter"
+	"github.com/rs/zerolog/log"
+	"os"
+	"regexp"
+)
+
+// Parse "{{< figure align=aligncenter width=768 src="Cedar_trail_waterfall-768x1024.jpg" alt="" >}}"
+// and extract "src" and "alt" attributes using regular expressions
+var _figureShortCodeRegEx = regexp.MustCompile(`{{<\s*?figure.*?>\s*}}`)
+
+type Result struct {
+	numImageWithAlt    int
+	numImageMissingAlt int
+	numImageUpdated    int
+}
+
+func (r Result) NumImageWithAlt() int {
+	return r.numImageWithAlt
+}
+
+func (r Result) NumImageMissingAlt() int {
+	return r.numImageMissingAlt
+}
+
+func (r Result) NumImageUpdated() int {
+	return r.numImageUpdated
+}
+
+func ProcessFile(ctx context.Context, path string, updateInline bool) (*Result, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", path, err)
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+	var frontmatterData any
+	log.Debug().
+		Str("path", path).
+		Msg("Parsing frontmatter")
+	mdBody, err := frontmatter.Parse(f, &frontmatterData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse frontmatter in file %s: %w", path, err)
+	}
+	if len(mdBody) == 0 {
+		log.Debug().
+			Str("path", path).
+			Msg("No markdown body found, skipping")
+		return &Result{}, nil
+	}
+
+	// Check if the body contains images
+	// and if they are missing alt text
+	matches := _figureShortCodeRegEx.FindAll(mdBody, -1)
+	if len(matches) == 0 {
+		return &Result{
+			numImageWithAlt:    0,
+			numImageMissingAlt: 0,
+			numImageUpdated:    0,
+		}, nil
+	}
+
+	numImageWithAlt := 0
+	for _, match := range matches {
+		if len(_figureShortCodeRegEx.FindSubmatch(match)) > 2 &&
+			len(_figureShortCodeRegEx.FindSubmatch(match)[2]) > 0 {
+			numImageWithAlt++
+		}
+	}
+	numImageMissingAlt := len(matches) - numImageWithAlt
+	if updateInline {
+		return nil, fmt.Errorf("inline update not supported yet")
+	}
+
+	return &Result{
+		numImageWithAlt:    numImageWithAlt,
+		numImageMissingAlt: numImageMissingAlt,
+		numImageUpdated:    0,
+	}, nil
+}


### PR DESCRIPTION
- [x] catch images missing alt
- [ ] auto-suggest good alt for the image via LLM