### PR TITLE
ci: fix release config

### DIFF
--- a/.github/workflows/release-hugomanager.yaml
+++ b/.github/workflows/release-hugomanager.yaml
@@ -45,8 +45,8 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          custom_tag: ${{ steps.read-version.outputs.version }}
-          tag_prefix: "hugomanager-"  # To prevent extra "v" in the prefix
+          custom_tag: "${{ steps.read-version.outputs.version }}-hugomanager"
+          tag_prefix: ""  # To prevent extra "v" in the prefix
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   releaseBinary:


### PR DESCRIPTION
Release failed with

```
  ⨯ release failed after 0s                  error=failed to parse tag 'hugomanager-0.1.1' as semver: Invalid Semantic Version
```

This fixes that