### PR TITLE
Added ap_outbox to custom post types

### DIFF
--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -200,7 +200,7 @@ func (p *Parser) getWebsiteInfo(feed *rss.Feed, authors []string) (*WebsiteInfo,
 				}
 				posts = append(posts, *post)
 			}
-		case "avada_portfolio", "avada_faq":
+		case "avada_portfolio", "avada_faq", "ap_outbox":
 			// TODO: let user pass custom post types from CLI arguments ?
 			// Most custom post types are more or less regular posts handled with special templates
 			// and having their own archives, aside from blog posts.


### PR DESCRIPTION
Handles #130 -- there's not much that `ap_outbox` seems to be doing differently, except automatic posting to ActivityPub. No obvious extra fields found in my archive.