### PR TITLE
Hugo manager release

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/generate_hugo_config.go
+++ b/src/wp2hugo/internal/hugogenerator/generate_hugo_config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ashishb/wp2hugo/src/wp2hugo/internal/wpparser"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
-	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -92,7 +91,7 @@ func updateConfig(siteDir string, info wpparser.WebsiteInfo) error {
 	}
 	// Ref: https://adityatelange.github.io/hugo-PaperMod/posts/papermod/papermod-faq/
 	config.Title = info.Title()
-	config.BaseURL = info.Link()
+	config.BaseURL = info.Link().String()
 	config.LanguageCode = info.Language()
 	config.Taxonomies.Category = hugopage.CategoryName
 	config.Taxonomies.Tag = hugopage.TagName
@@ -139,17 +138,12 @@ func addNavigationLinks(info wpparser.WebsiteInfo, config *_HugoConfig) error {
 	if len(info.NavigationLinks()) <= 0 {
 		return nil
 	}
-	hostName, err := url.Parse(info.Link())
-	if err != nil {
-		return fmt.Errorf("error parsing host name: %s", err)
-	}
 
 	searchPresent := false
-
 	for i, link := range info.NavigationLinks() {
 		config.Menu.Main = append(config.Menu.Main, _HugoNavMenu{
 			Name:   link.Title,
-			URL:    hugopage.ReplaceAbsoluteLinksWithRelative(hostName.Host, link.URL),
+			URL:    hugopage.ReplaceAbsoluteLinksWithRelative(info.Link().Host, link.URL),
 			Weight: i + 1,
 		})
 		if strings.HasSuffix(link.URL, "/search/") {

--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 )
 
 type MediaCache struct {
@@ -20,6 +21,12 @@ func New(cacheDirPath string) MediaCache {
 }
 
 func (m MediaCache) GetReader(url string) (io.Reader, error) {
+	if strings.Contains(url, "blog/blog") {
+		log.Panic().
+			Str("url", url).
+			Msg("media url contains blog/blog")
+	}
+
 	if err := utils.CreateDirIfNotExist(m.cacheDirPath); err != nil {
 		return nil, fmt.Errorf("error creating cache directory: %s", err)
 	}
@@ -27,10 +34,15 @@ func (m MediaCache) GetReader(url string) (io.Reader, error) {
 	key := getSHA256(url)
 	file, err := os.OpenFile(path.Join(m.cacheDirPath, key), os.O_RDONLY, 0644)
 	if err == nil {
-		log.Info().Msgf("media %s found in cache", url)
+		log.Info().
+			Str("url", url).
+			Msg("media found in cache")
 		return file, nil
 	}
-	log.Info().Msgf("media %s will be fetched", url)
+
+	log.Info().
+		Str("url", url).
+		Msg("media will be fetched")
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching media %s: %s", url, err)

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -258,9 +259,14 @@ func (p *Parser) getWebsiteInfo(feed *rss.Feed, authors []string) (*WebsiteInfo,
 		}
 	}
 
+	linkURL, err := url.Parse(feed.Link)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing feed link: %w", err)
+	}
+
 	websiteInfo := WebsiteInfo{
 		title:       feed.Title,
-		link:        feed.Link,
+		link:        linkURL,
 		Description: feed.Description,
 		pubDate:     feed.PubDateParsed,
 		language:    feed.Language,

--- a/src/wp2hugo/internal/wpparser/wp_website_info.go
+++ b/src/wp2hugo/internal/wpparser/wp_website_info.go
@@ -1,12 +1,13 @@
 package wpparser
 
 import (
+	"net/url"
 	"time"
 )
 
 type WebsiteInfo struct {
 	title       string
-	link        string
+	link        *url.URL
 	Description string
 
 	pubDate  *time.Time
@@ -49,7 +50,7 @@ func (w *WebsiteInfo) Title() string {
 	return w.title
 }
 
-func (w *WebsiteInfo) Link() string {
+func (w *WebsiteInfo) Link() *url.URL {
 	return w.link
 }
 


### PR DESCRIPTION
Earlier, the media path for a media /blog/2.png on a blog hosted on "example.com/blog" will be incorrect (example.com/blog/blog/2.png).

This commit fixes that.

Ref: https://github.com/ashishb/wp2hugo/issues/155