### PR TITLE
fix: long post titles should not imply long file names

### DIFF
--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
+const _filenameSizeLimit = 200
+
 var (
 	errTrashItem = fmt.Errorf("item is in trash")
 	// \p{L} matches any letter from any language while \w matches only ASCII letters
@@ -102,6 +104,13 @@ func (i CommonFields) Filename() string {
 	}
 	if len(str1) > 1 {
 		str1 = strings.TrimSuffix(str1, "-")
+	}
+
+	if len(str1) > _filenameSizeLimit {
+		log.Warn().
+			Str("title", i.Title).
+			Msgf("Filename is too long, truncating to %d characters", _filenameSizeLimit)
+		str1 = str1[:_filenameSizeLimit]
 	}
 
 	if i.Title != str1 {


### PR DESCRIPTION
Sometimes, post titles can be arbitrarily long while the file names are limited to 255 characters.

So, for long post titles, convert them into short file names (up to 200 characters).

Ref: https://github.com/ashishb/wp2hugo/issues/158