### PR TITLE
Support WPML translations using parameter URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ make build_prod
 1. [x] Migrate [Avada](https://themeforest.net/item/avada-responsive-multipurpose-theme/2833226) custom post types (FAQ, Portfolios)
 1. [x] Set the WordPress homepage correctly
 1. [x] Create WordPress author page
+1. [x] Migrate [WPML](https://wpml.org/) translated posts, pages and custom post types that use the [URL parameter scheme](https://wpml.org/documentation/getting-started-guide/language-setup/language-url-options/#language-name-added-as-a-parameter) (switch the WPML language URL option prior to exporting your blog content to XML).
 
 ### Migrate permalinks
 

--- a/src/wp2hugo/internal/wpparser/wp_parser_setup.go
+++ b/src/wp2hugo/internal/wpparser/wp_parser_setup.go
@@ -116,7 +116,6 @@ func titleToFilename(title string) string {
 	return str1
 }
 
-
 func findSlugAndParams(parts []string) (string, string) {
 	file := ""
 	params := ""


### PR DESCRIPTION
For reference : https://wpml.org/documentation/getting-started-guide/language-setup/language-url-options/#language-name-added-as-a-parameter

This slightly changes the Markdown files naming scheme, trying first to re-use the slug of the WordPress page (last member of the URL path). If no slug is found, this defaults to the current logic, using normalized title. Then, we try to extract the ?lang=XX or &lang=XX parameter if any.

The best case scenario is this :

- WP input : `https://website.com/some-page/` -> Hugo file `content/pages/some-page.md`,
- WP input `https://website.com/some-page/?lang=fr` -> Hugo file `content/pages/some-page.fr.md`

This automatically follows Hugo translating scheme. However, if the page slug was also translated through WPML, this doesn't work as-is anymore.