### PR TITLE
Images: improve handling

### DIFF
--- a/src/wp2hugo/cmd/wp2hugo/main.go
+++ b/src/wp2hugo/cmd/wp2hugo/main.go
@@ -16,6 +16,7 @@ var (
 	sourceFile                     = flag.String("source", "", "file path to the source WordPress XML file")
 	outputDir                      = flag.String("output", "/tmp", "dir path to write the Hugo-generated data to")
 	downloadMedia                  = flag.Bool("download-media", false, "download media files embedded in the WordPress content")
+	downloadAll                    = flag.Bool("download-all", false, "download all media from WordPress library, whether used in content or not")
 	continueOnMediaDownloadFailure = flag.Bool("continue-on-media-download-error", false, "continue processing even if one or more media downloads fail")
 	generateNgnixConfig            = flag.Bool("generate-nginx-config", true, "generate Nginx configuration for the generated Hugo website for redirecting WordPress GUIDs to Hugo URLs")
 	authors                        = flag.String("authors", "", "CSV list of author name(s), if provided, only posts by these authors will be processed")
@@ -67,6 +68,6 @@ func getWebsiteInfo(filePath string) (*wpparser.WebsiteInfo, error) {
 func generate(info wpparser.WebsiteInfo, outputDirPath string) error {
 	log.Debug().Msgf("Output: %s", outputDirPath)
 	generator := hugogenerator.NewGenerator(outputDirPath, *font, mediacache.New(*mediaCacheDir),
-		*downloadMedia, *continueOnMediaDownloadFailure, *generateNgnixConfig, info)
+		*downloadMedia, *downloadAll, *continueOnMediaDownloadFailure, *generateNgnixConfig, info)
 	return generator.Generate()
 }

--- a/src/wp2hugo/internal/hugogenerator/hugo_generator_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_generator_test.go
@@ -22,7 +22,7 @@ func TestFootnote(t *testing.T) {
 	require.Len(t, post.Footnotes, 1)
 	require.NotNil(t, post.CommonFields)
 
-	generator := NewGenerator("/tmp", "", nil, false, false, true, *websiteInfo)
+	generator := NewGenerator("/tmp", "", nil, false, false, false, true, *websiteInfo)
 	url1, err := url.Parse(post.GUID.Value)
 	require.NoError(t, err)
 	hugoPage, err := generator.newHugoPage(url1, post.CommonFields)

--- a/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/hugo_page.go
@@ -98,6 +98,12 @@ func (page *Page) Markdown() string {
 	return page.markdown
 }
 
+func (page *Page) Replace(replacementMap map[string]string) {
+	for old, new := range replacementMap {
+		page.markdown = strings.ReplaceAll(page.markdown, old, new)
+	}
+}
+
 func (page Page) Write(w io.Writer) error {
 	if err := page.writeMetadata(w); err != nil {
 		return err

--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -50,7 +50,7 @@ func waitOrStop(resp *http.Response) (int, bool) {
 		stop = true
 
 	default:
-		
+
 	}
 
 	return timeout, stop

--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -27,11 +27,11 @@ func waitOrStop(resp *http.Response) (int, bool) {
 	stop := false
 	switch resp.StatusCode {
 
-	case 200:
+	case http.StatusOK:
 		// Success
 		stop = true
 
-	case 429:
+	case http.StatusTooManyRequests:
 		// HTTP error 429 = too many requests,
 		// aka we are getting rate-thresholded.
 		// Some servers may tell us when we are allowed to retry:
@@ -44,7 +44,7 @@ func waitOrStop(resp *http.Response) (int, bool) {
 			timeout = 2
 		}
 
-	case 404:
+	case http.StatusNotFound:
 		// HTTP error 404 = not found
 		// Useless to retry downloading
 		stop = true

--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -80,7 +80,7 @@ func (m MediaCache) GetReader(url string) (io.Reader, error) {
 		Str("url", url).
 		Msg("media will be fetched")
 
-	var http_err error = fmt.Errorf("generic error")
+	var http_err error
 	var resp *http.Response = nil
 
 	retries := 0

--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -3,13 +3,15 @@ package mediacache
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/ashishb/wp2hugo/src/wp2hugo/internal/utils"
-	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
 	"os"
 	"path"
 	"strings"
+	"time"
+
+	"github.com/ashishb/wp2hugo/src/wp2hugo/internal/utils"
+	"github.com/rs/zerolog/log"
 )
 
 type MediaCache struct {
@@ -18,6 +20,40 @@ type MediaCache struct {
 
 func New(cacheDirPath string) MediaCache {
 	return MediaCache{cacheDirPath: cacheDirPath}
+}
+
+func waitOrStop(resp *http.Response) (int, bool) {
+	timeout := 1
+	stop := false
+	switch resp.StatusCode {
+
+	case 200:
+		// Success
+		stop = true
+
+	case 429:
+		// HTTP error 429 = too many requests,
+		// aka we are getting rate-thresholded.
+		// Some servers may tell us when we are allowed to retry:
+		retryAfter := resp.Header.Get("Retry-After")
+		if retryAfter != "" {
+			if seconds, err := time.ParseDuration(retryAfter + "s"); err == nil {
+				timeout = int(seconds.Seconds())
+			}
+		} else {
+			timeout = 2
+		}
+
+	case 404:
+		// HTTP error 404 = not found
+		// Useless to retry downloading
+		stop = true
+
+	default:
+		
+	}
+
+	return timeout, stop
 }
 
 func (m MediaCache) GetReader(url string) (io.Reader, error) {
@@ -43,9 +79,25 @@ func (m MediaCache) GetReader(url string) (io.Reader, error) {
 	log.Info().
 		Str("url", url).
 		Msg("media will be fetched")
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching media %s: %s", url, err)
+
+	var http_err error = fmt.Errorf("generic error")
+	var resp *http.Response = nil
+
+	retries := 0
+	timeout := 1
+	stop := false
+	for retries < 5 && !stop {
+		// Send at most 1 request per second
+		// to avoid hammering servers and getting thresholded
+		time.Sleep(time.Duration(timeout) * time.Second)
+		resp, http_err = http.Get(url)
+		timeout, stop = waitOrStop(resp)
+		retries++
+		timeout *= retries
+	}
+
+	if http_err != nil {
+		return nil, fmt.Errorf("error fetching media %s: %s", url, http_err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("error fetching media %s: %s", url, resp.Status)


### PR DESCRIPTION
1. add a `--download-all` CLI argument to enable downloading all media from WP library into `/static/`,
2. upon media downloading from origin server, gracefully handle servers requests rate thresholding (HTTP error 429: too many connections) with retries and timeouts, possibly using the returned HTTP header `Retry-After` if provided
3. finish the job started with 9e1fe1e550b041bbfcd2054a7fef9e7cb418b831: when downscaled WP image thumbnail links have been converted to original (full-res) size, ensure all thumbnails links in the post are converted to full-res too.