### PR TITLE
Support Youtube with [embed] WP shortcode

### DIFF
--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter.go
@@ -10,7 +10,7 @@ import (
 // Example: Plain-text Youtube URLs on their own line in post content are turned by WP into embeds
 // The YouTube Lyte plug-in additionally uses "httpa://" for audio and "httpv://" for video embeds:
 // https://wordpress.com/plugins/wp-youtube-lyte
-var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)http[sav]?://(?:m\.|www\.)?(?:youtu\.be|youtube\.com)/(?:watch|w)\?v=([^&\s]+)`)
+var _YoutubeRegEx = regexp.MustCompile(`(?m)(^|\s)(?:[embed])http[sav]?://(?:m\.|www\.)?(?:youtu\.be|youtube\.com)/(?:watch|w)\?v=([^&\s]+)(?:[/embed])`)
 
 func replacePlaintextYoutubeURL(htmlData string) string {
 	log.Debug().

--- a/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugopage/wordpress_youtube_converter_test.go
@@ -24,6 +24,12 @@ func TestReplaceYoutubeURL3(t *testing.T) {
 	assert.Equal(t, expected, replacePlaintextYoutubeURL(htmlData))
 }
 
+func TestReplaceYoutubeURL4(t *testing.T) {
+	const htmlData = "[embed]https://www.youtube.com/watch?v=gJ7AAJXHeeg[/embed]"
+	const expected = "{{< youtube gJ7AAJXHeeg >}}"
+	assert.Equal(t, expected, replacePlaintextYoutubeURL(htmlData))
+}
+
 func TestReplaceNonPlaintextYouTubeURL(t *testing.T) {
 	const htmlData = `This is a test with a youtube link <a href="https://www.youtube.com/watch?v=gJ7AAJXHeeg" and
 		embed <iframe width="560" height="315" src="https://www.youtube.com/embed/Wz6ml5SpkKM?si=rrx_5_80TE3Mz7Co"


### PR DESCRIPTION
Note: embeds with other video services still don't work…