### PR TITLE
Allow users to specify custom post types as CSV argument when calling the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,26 @@ Feel free to contact me if you want to license this commercially.
 ```bash
 $ wp2hugo
 Usage of wp2hugo:
- -authors string
-   CSV list of author name(s), if provided, only posts by these authors will be processed
-  -color-log-output
-   enable colored log output, set false to structured JSON log (default true)
-  -continue-on-media-download-error
-   continue processing even if one or more media downloads fail
-  -download-media
-   download media files embedded in the WordPress content
-  -font string
-   custom font for the output website (default "Lexend")
-  -media-cache-dir string
-   dir path to cache the downloaded media files (default "/tmp/wp2hugo-cache")
-  -output string
-   dir path to write the Hugo-generated data to (default "/tmp")
-  -source string
-   file path to the source WordPress XML file
+  --authors string
+    CSV list of author name(s), if provided, only posts by these authors will be processed (using author slug)
+  --color-log-output
+    enable colored log output, set false to structured JSON log (default true)
+  --continue-on-media-download-error
+    continue processing even if one or more media downloads fail
+  --download-media
+    download media files embedded in the WordPress content
+  --download-all
+    download all media files from the WordPress library, whether embedded in content or not
+  --font string
+    custom font for the output website (default "Lexend")
+  --media-cache-dir string
+    dir path to cache the downloaded media files (default "/tmp/wp2hugo-cache")
+  --output string
+    dir path to write the Hugo-generated data to (default "/tmp")
+  --source string
+    file path to the source WordPress XML file
+  --custom-post-types string
+    CSV list of additional WordPress custom post types to import (using type slug)
 ```
 
 ### Build from source
@@ -104,11 +108,13 @@ More details on [the documentation](https://github.com/ashishb/wp2hugo/tree/main
 1. [x] Migrate posts
 1. [x] Migrate pages in a hierarchical way, using Hugo [page bundles](https://gohugo.io/content-management/page-bundles/),
 1. [x] Migrate tags, categories and [custom taxonomies](https://learn.wordpress.org/lesson/custom-taxonomies/) for all types of posts,
-1. [x] Migrate [Avada](https://themeforest.net/item/avada-responsive-multipurpose-theme/2833226) custom post types (FAQ, Portfolios)
-1. [x] Migrate [Woocommerce](https://woocommerce.com/) products and product variations (custom post types) into Hugo page bundles, along with their attributes (custom taxonomies, custom fields),
 1. [x] Set the WordPress homepage correctly
 1. [x] Create WordPress author page
-1. [x] Migrate [WPML](https://wpml.org/) translated posts, pages, and custom post types that use the [URL parameter scheme](https://wpml.org/documentation/getting-started-guide/language-setup/language-url-options/#language-name-added-as-a-parameter) (switch the WPML language URL option prior to exporting your blog content to XML).
+1. [x] Migrate [WPML](https://wpml.org/) translated posts, pages, and custom post types that use the [URL parameter scheme](https://wpml.org/documentation/getting-started-guide/language-setup/language-url-options/#language-name-added-as-a-parameter) (switch the WPML language URL option prior to exporting your blog content to XML),
+1. [x] Migrate any arbitrary WordPress [custom post type](https://learn.wordpress.org/lesson/custom-post-types/) and store them into their own `/content/post-type` subfolder (hierarchical custom posts are fully supported):
+  - [Avada](https://themeforest.net/item/avada-responsive-multipurpose-theme/2833226) FAQ and Portfolios types are supported natively,
+  - [Woocommerce](https://woocommerce.com/) products and product variations types are supported natively,
+  - user can specify a CSV list of arbitrary post types, using the `--custom-post-types` argument when calling the executable. Only post types that have a publishing status (`<wp:status>` in export XML) matching one of the [values of native posts](https://wordpress.org/documentation/article/post-status/) are supported.
 
 ### Migrate permalinks
 

--- a/src/wp2hugo/cmd/wp2hugo/main.go
+++ b/src/wp2hugo/cmd/wp2hugo/main.go
@@ -27,6 +27,8 @@ var (
 	// Custom font for Hugo's papermod theme
 	font           = flag.String("font", "Lexend", "custom font for the output website")
 	colorLogOutput = flag.Bool("color-log-output", true, "enable colored log output, set false to structured JSON log")
+
+	customPostTypes = flag.String("custom-post-types", "", "CSV list of custom post types to import")
 )
 
 func main() {
@@ -63,7 +65,11 @@ func getWebsiteInfo(filePath string) (*wpparser.WebsiteInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parser.Parse(file, strings.Split(*authors, ","))
+
+	defaultCustomPosts := []string{"avada_portfolio", "avada_faq", "product", "product_variation"}
+	defaultCustomPosts = append(defaultCustomPosts, strings.Split(*customPostTypes, ",")...)
+	
+	return parser.Parse(file, strings.Split(*authors, ","), defaultCustomPosts)
 }
 
 func generate(info wpparser.WebsiteInfo, outputDirPath string) error {

--- a/src/wp2hugo/cmd/wp2hugo/main.go
+++ b/src/wp2hugo/cmd/wp2hugo/main.go
@@ -68,7 +68,7 @@ func getWebsiteInfo(filePath string) (*wpparser.WebsiteInfo, error) {
 
 	defaultCustomPosts := []string{"avada_portfolio", "avada_faq", "product", "product_variation"}
 	defaultCustomPosts = append(defaultCustomPosts, strings.Split(*customPostTypes, ",")...)
-	
+
 	return parser.Parse(file, strings.Split(*authors, ","), defaultCustomPosts)
 }
 

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -480,14 +480,7 @@ func (g Generator) writeCustomPosts(outputDirPath string, info wpparser.WebsiteI
 	}
 
 	// Properly set page bundle type
-	postTypes := []string{
-		"products",
-		"product_variations",
-		"avada_faqs",
-		"avada_portfolios",
-	}
-
-	for _, postType := range postTypes {
+	for _, postType := range info.CustomPostTypes() {
 		sanitizePostType(outputDirPath, postType)
 	}
 

--- a/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_gen_setup.go
@@ -406,6 +406,11 @@ func sanitizePageBundles(dirPath string) error {
 }
 
 func sanitizePostType(outputDirPath string, postType string) {
+	// Content type subfolder always uses the plural form of the type name
+	if !strings.HasSuffix(postType, "s") {
+		postType += "s"
+	}
+
 	if err := sanitizePageBundles(path.Join(outputDirPath, "content", postType)); err != nil {
 		// Intentionally ignore the error
 		fmt.Println("Error sanitizing page bundles:", err)

--- a/src/wp2hugo/internal/hugogenerator/hugo_generator_test.go
+++ b/src/wp2hugo/internal/hugogenerator/hugo_generator_test.go
@@ -15,7 +15,7 @@ func TestFootnote(t *testing.T) {
 	require.NoError(t, err)
 
 	parser := wpparser.NewParser()
-	websiteInfo, err := parser.Parse(file, nil)
+	websiteInfo, err := parser.Parse(file, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, websiteInfo.Posts(), 1)
 
@@ -39,7 +39,7 @@ func TestPost(t *testing.T) {
 	require.NoError(t, err)
 
 	parser := wpparser.NewParser()
-	websiteInfo, err := parser.Parse(file, nil)
+	websiteInfo, err := parser.Parse(file, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, websiteInfo.Posts(), 1)
 

--- a/src/wp2hugo/internal/wpparser/wp_website_info.go
+++ b/src/wp2hugo/internal/wpparser/wp_website_info.go
@@ -25,6 +25,10 @@ type WebsiteInfo struct {
 	customPosts     []CustomPostInfo
 	taxonomies      []TaxonomyInfo
 
+	// WordPress non-native post types slugs to import.
+	// By default, we handle avada_portfolio, avada_faq (Advada theme),
+	// product, product_variation (WooCommerce plugin).
+	// This is mapped to the <wp:post_type> field in the XML export
 	customPostTypes []string
 
 	postIDToAttachmentCache map[string][]AttachmentInfo

--- a/src/wp2hugo/internal/wpparser/wp_website_info.go
+++ b/src/wp2hugo/internal/wpparser/wp_website_info.go
@@ -25,6 +25,8 @@ type WebsiteInfo struct {
 	customPosts     []CustomPostInfo
 	taxonomies      []TaxonomyInfo
 
+	customPostTypes []string
+
 	postIDToAttachmentCache map[string][]AttachmentInfo
 }
 
@@ -89,6 +91,10 @@ func (w *WebsiteInfo) Posts() []PostInfo {
 
 func (w *WebsiteInfo) CustomPosts() []CustomPostInfo {
 	return w.customPosts
+}
+
+func (w *WebsiteInfo) CustomPostTypes() []string {
+	return w.customPostTypes
 }
 
 func getPostIDToAttachmentsMap(attachments []AttachmentInfo) map[string][]AttachmentInfo {


### PR DESCRIPTION
Extend current Avada/WooCommerce support by allowing any arbitrary custom type.

This makes wp2hugo pretty much feature-complete from my perspective.

The native posts and pages code could possibly be refactored to use the (more generic) custom post type approach.