### PR TITLE
chore: fix lint issues

### DIFF
--- a/src/wp2hugo/cmd/hugomanager/cmd/move_content_with_attachments.go
+++ b/src/wp2hugo/cmd/hugomanager/cmd/move_content_with_attachments.go
@@ -26,7 +26,7 @@ var moveContentWithAttachmentsCmd = &cobra.Command{
 
 		modifiedCount := 0
 		action := func(path string, updateInline bool) error {
-			processedFile, err := contentmigratorv1.ProcessFile(path, updateInline)
+			processedFile, err := contentmigratorv1.ProcessFile(cmd.Context(), path, updateInline)
 			if err != nil {
 				return err
 			}

--- a/src/wp2hugo/cmd/wp2hugo/main.go
+++ b/src/wp2hugo/cmd/wp2hugo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"path"
@@ -42,13 +43,13 @@ func main() {
 	if len(*outputDir) == 0 {
 		log.Fatal().Msg("Output directory is required")
 	}
-	err := handle(*sourceFile)
+	err := handle(context.Background(), *sourceFile)
 	if err != nil {
 		log.Fatal().Msgf("Error: %s", err)
 	}
 }
 
-func handle(filePath string) error {
+func handle(ctx context.Context, filePath string) error {
 	log.Debug().
 		Str("source", filePath).
 		Msg("Reading website export")
@@ -56,7 +57,7 @@ func handle(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return generate(*websiteInfo, *outputDir)
+	return generate(ctx, *websiteInfo, *outputDir)
 }
 
 func getWebsiteInfo(filePath string) (*wpparser.WebsiteInfo, error) {
@@ -72,9 +73,9 @@ func getWebsiteInfo(filePath string) (*wpparser.WebsiteInfo, error) {
 	return parser.Parse(file, strings.Split(*authors, ","), defaultCustomPosts)
 }
 
-func generate(info wpparser.WebsiteInfo, outputDirPath string) error {
+func generate(ctx context.Context, info wpparser.WebsiteInfo, outputDirPath string) error {
 	log.Debug().Msgf("Output: %s", outputDirPath)
 	generator := hugogenerator.NewGenerator(outputDirPath, *font, mediacache.New(*mediaCacheDir),
 		*downloadMedia, *downloadAll, *continueOnMediaDownloadFailure, *generateNgnixConfig, info)
-	return generator.Generate()
+	return generator.Generate(ctx)
 }

--- a/src/wp2hugo/internal/gitutils/git_move.go
+++ b/src/wp2hugo/internal/gitutils/git_move.go
@@ -1,6 +1,7 @@
 package gitutils
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -9,7 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func GitMove(path string, newFilePath string) error {
+func GitMove(ctx context.Context, path string, newFilePath string) error {
 	if !utils.FileExists(path) {
 		return fmt.Errorf("file '%s' does not exist", path)
 	}
@@ -18,7 +19,7 @@ func GitMove(path string, newFilePath string) error {
 		return fmt.Errorf("file '%s' already exists", newFilePath)
 	}
 
-	cmd := exec.Command("git", "mv", path, newFilePath)
+	cmd := exec.CommandContext(ctx, "git", "mv", path, newFilePath)
 	// Run the command in the directory of the file for "git" to work
 	cmd.Dir = filepath.Dir(path)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Fix `context` related lint issues pointed out by golangci-lint upgrade from 2.1 -> 2.3