### PR TITLE
Fix for #238 - nil pointer crash

### DIFF
--- a/src/wp2hugo/internal/mediacache/media_cache_setup.go
+++ b/src/wp2hugo/internal/mediacache/media_cache_setup.go
@@ -32,7 +32,7 @@ func waitOrStop(resp *http.Response) (int, bool) {
 	// May want to bump the timeout but since we've not got a valid
 	// response, it's not entirely clear if we even made a request.
 	if resp == nil {
-		return timeout, stop
+		return timeout, false
 	}
 
 	switch resp.StatusCode {


### PR DESCRIPTION
`waitOrStop` now guards against `resp == nil` by returning our default `timeout` and `stop` values (since we don't have a valid response object, we can't really decide whether we need to bump the timeout but we probably don't want to stop because it might be transient.)

Should fix #238.