### PR TITLE
Organize posts and pages inside year folders OR year and month folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## add date prefix to posts (only year folders OR year and month folders).
+
 # WordPress to Hugo Static site migrator
 
 [![Featured on Hacker News](https://hackerbadge.now.sh/api?id=41377331)](https://news.ycombinator.com/item?id=41377331)


### PR DESCRIPTION
Hi, 
It could be useful to allow users to organize posts and pages based on date, just like images are stored in wp-content. 

Based on `hugomanager`  option "`move-post-next-to-attachments`", it would be nice to allow sorting posts and pages in a folder hierarchy (year folders OR year and month folders) just like did the `wp2hugo` script  gets with the `static/wp-content` folder.
So it would result with something like below in the hugo folder when using year and folder  : 
Hugo_dir
└── content
 |  └── posts
 |       |   ├── 2025
 | |       │   ├── 01
 | |        │   │   ├── mypost.md
 | |        │   │   ├── images
 | |        │   │   │   ├── image1-mypost.png
 | |        │   │   │   ├── image2-mypost.png
 | |       │   └── 11
 | |        │   ├── anotherpost.md
 | |        │   ├── images
 | |        │   │   │   ├── image1-anotherpost.png
 | |        │   │   │   ├── image2-anotherpost.png
 |       |   └── 2026
 | |       │   ├── 03
 | |        │   ├── newpost.md
 | |        │   ├── images
 | |        │   │   │   ├── image1-newpost.png


And the same organization for pages

Thank you for helping to WP migration.